### PR TITLE
design: 전체식단페이지 디자인 수정 완료(#7)

### DIFF
--- a/Front/src/CSS/AllDietPage.css
+++ b/Front/src/CSS/AllDietPage.css
@@ -3,195 +3,235 @@
     width: 100%;
     height: 100vh;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    background-color: #f8f9fa;
+    background: #f8f9fa;
+    gap: 20px;
+}
+
+.allDietPage_loading_spinner {
+    width: 48px;
+    height: 48px;
+    border: 3px solid rgba(157, 146, 116, 0.2);
+    border-top: 3px solid #9d9274;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.allDietPage_loading_spinner_text {
+    font-size: 15px;
+    color: #666;
+    font-weight: 500;
+    letter-spacing: -0.2px;
 }
 
 /* 전체 컨테이너 */
 .allDietPage_container {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 20px 24px 120px 24px;
+    position: relative;
+    height: calc(100vh - 130px);
+
+}
+
+/* 식단 그리드 */
+.allDietPage_meals_grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, minmax(180px, 1fr)); 
+    gap: 20px;
     width: 100%;
-    height: 85vh;
-    margin-top: 20px;
-    max-width: 414px;
-    margin: 20px auto 0 auto;
-    position: relative;
+    max-width: 100%;
+    height: 100%;
+    margin: 0 auto;
+    transition: all 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    opacity: 1;
+    transform: translateX(0);
 }
 
-/* 리스트 컨테이너 */
-.allDietPage_list_container {
-    width: 85%;
-    height: 90%;
-    max-height: 90%;
-    padding: 10px;
-    background-color: white;
-    border-radius: 15px;
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 15px;
-    overflow-y: auto;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-}
 
-/* 스크롤바 숨김 */
-.allDietPage_list_container::-webkit-scrollbar {
-    display: none;
-}
-
-.allDietPage_list_container {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-}
-
-/* 아이템 카드 */
-.allDietPage_item_card {
-    width: calc(50% - 7.5px);
-    height: 280px;
-    border-radius: 16px;
-    overflow: hidden;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-    border: none;
-    position: relative;
+/* 메인 카드 */
+.allDietPage_meal_card {
     background: white;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
+    position: relative;
+    width: 100%;
+    cursor: pointer;
+}
+
+.allDietPage_meal_card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.12);
+}
+
+/* 빈 카드 */
+.allDietPage_empty_card {
+    width: 100%;
+    height: 100%;
+    visibility: hidden;
+}
+
+/* 시간 태그 */
+.allDietPage_meal_time {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    padding: 6px 12px;
+    border-radius: 16px;
+    z-index: 2;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.allDietPage_item_card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+.allDietPage_time_label {
+    font-size: 11px;
+    font-weight: 600;
+    color: #9d9274;
+    letter-spacing: -0.2px;
 }
 
-/* 이미지 컨테이너 */
-.allDietPage_item_image_container {
-    width: 100%;
-    height: 200px;
+/* 이미지 */
+.allDietPage_meal_image {
+    height: 40%;
     overflow: hidden;
-    background-color: #f8f9fa;
     position: relative;
 }
 
-.allDietPage_item_image {
+.allDietPage_meal_image_content {
     width: 100%;
     height: 100%;
     object-fit: cover;
     transition: transform 0.3s ease;
 }
 
-.allDietPage_item_card:hover .allDietPage_item_image {
+.allDietPage_meal_card:hover .allDietPage_meal_image_content {
     transform: scale(1.05);
 }
 
-/* 카테고리 태그 */
-.allDietPage_category_tag {
-    position: absolute;
-    top: 12px;
-    left: 12px;
+/* 정보 영역 */
+.allDietPage_meal_info {
+    padding: 18px;
     background: white;
-    color: #333;
-    padding: 6px 12px;
-    border-radius: 16px;
-    font-size: 11px;
-    font-weight: 700;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-/* 아이템 메타 정보 */
-.allDietPage_item_meta {
-    height: 80px;
-    padding: 24px;
-    background: white;
+    height: 40%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
 }
 
-.allDietPage_item_title {
-    font-size: 18px;
+.allDietPage_meal_info_name {
+    font-size: 17px;
     font-weight: 700;
     color: #333;
-    margin-bottom: 8px;
-    letter-spacing: -0.4px;
-    line-height: 1.2;
+    margin-bottom: 4px;
+    letter-spacing: -0.3px;
     overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
+    line-height: 1.2;
 }
 
-.allDietPage_item_description {
-    font-size: 14px;
+.allDietPage_meal_info_description {
+    font-size: 13px;
     color: #666;
-    margin-bottom: 16px;
-    line-height: 1.5;
+    margin-bottom: 12px;
+    line-height: 1.3;
     letter-spacing: -0.1px;
     overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
 }
 
-.allDietPage_item_nutrition {
+/* 영양 정보 */
+.allDietPage_nutrition_info {
     display: flex;
-    gap: 12px;
+    gap: 8px;
+    margin-top: auto;
+    margin-bottom: 8px;
 }
 
-.allDietPage_calories,
-.allDietPage_protein {
-    background: rgba(157, 146, 116, 0.1);
-    color: #9d9274;
-    padding: 6px 12px;
-    border-radius: 12px;
-    font-size: 12px;
+.allDietPage_nutrition_info1,
+.allDietPage_nutrition_info2 {
+    background: #9d9274;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 10px;
+    font-size: 10px;
     font-weight: 600;
     letter-spacing: -0.1px;
+    white-space: nowrap;
 }
 
-/* 빈 카드 (레이아웃 유지용) */
-.allDietPage_empty_card {
-    width: calc(50% - 7.5px);
-    height: 280px;
-    visibility: hidden;
+/* 가격 정보 */
+.allDietPage_price_info {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+    
 }
 
-/* 슬라이드 컨트롤 컨테이너 */
+.allDietPage_price {
+    background: linear-gradient(135deg, #ff6b6b 0%, #ff8e53 100%);
+    color: white;
+    padding: 8px 12px;
+    border-radius: 12px;
+    width: 100%;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: -0.2px;
+    box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
+    position: relative;
+    overflow: hidden;
+    transition: all 0.2s ease;
+}
+
+.allDietPage_price::before {
+    content: '₩';
+    font-size: 11px;
+    margin-right: 2px;
+    opacity: 0.9;
+}
+
+.allDietPage_price:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 107, 107, 0.4);
+}
+
+/* 슬라이드 컨트롤 */
 .allDietPage_slide_controls {
-    position: absolute;
-    bottom: 10px;
-    left: 50%;
-    transform: translateX(-50%);
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 20px;
-    z-index: 10;
-    background: rgba(255, 255, 255, 0.9);
-    backdrop-filter: blur(10px);
-    border-radius: 20px;
-    padding: 8px 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    gap: 24px;
 }
 
-/* 슬라이드 네비게이션 버튼 */
+/* 네비게이션 버튼 */
 .allDietPage_nav_button {
     background: transparent;
-    color: #666;
+    color: #9d9274;
     border: none;
-    width: 28px;
-    height: 28px;
-    border-radius: 6px;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.2s ease;
-    font-size: 14px;
+    font-size: 16px;
 }
 
 .allDietPage_nav_button:hover {
-    background: rgba(0, 0, 0, 0.1);
+    background: rgba(157, 146, 116, 0.1);
     color: #333;
 }
 
@@ -203,40 +243,24 @@
 /* 페이지 인디케이터 */
 .allDietPage_indicators {
     display: flex;
-    gap: 6px;
+    gap: 8px;
 }
 
 .allDietPage_indicator {
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
-    background: #ddd;
+    background: rgba(157, 146, 116, 0.3);
     cursor: pointer;
     transition: all 0.2s ease;
 }
 
 .allDietPage_indicator:hover {
-    background: #999;
+    background: rgba(157, 146, 116, 0.6);
 }
 
 .allDietPage_indicator.active {
-    background: #333;
-    width: 18px;
-    border-radius: 3px;
-}
-
-/* Ant Design Card 스타일 오버라이드 */
-.allDietPage_item_card .ant-card-body {
-    padding: 0;
-    height: 80px;
-}
-
-.allDietPage_item_card .ant-card-meta-title {
-    margin-bottom: 2px;
-    font-size: 14px;
-}
-
-.allDietPage_item_card .ant-card-meta-description {
-    font-size: 12px;
-    margin-bottom: 0;
+    background: #9d9274;
+    width: 24px;
+    border-radius: 4px;
 }

--- a/Front/src/CSS/AllDietPage.css
+++ b/Front/src/CSS/AllDietPage.css
@@ -1,12 +1,27 @@
-.ADPcontainer {
+/* 로딩 컨테이너 */
+.allDietPage_loading_container {
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f8f9fa;
+}
+
+/* 전체 컨테이너 */
+.allDietPage_container {
     display: flex;
     justify-content: center;
     width: 100%;
     height: 85vh;
     margin-top: 20px;
+    max-width: 414px;
+    margin: 20px auto 0 auto;
+    position: relative;
 }
 
-.ADPlistContainer {
+/* 리스트 컨테이너 */
+.allDietPage_list_container {
     width: 85%;
     height: 90%;
     max-height: 90%;
@@ -18,37 +33,210 @@
     flex-wrap: wrap;
     gap: 15px;
     overflow-y: auto;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.ADPlistContainer::-webkit-scrollbar {
+/* 스크롤바 숨김 */
+.allDietPage_list_container::-webkit-scrollbar {
     display: none;
 }
 
-.ADPitemCard {
-    width: calc(50% - 15px); /* 한 줄에 두 개씩 배치 */
-    height: auto; /* 카드 높이를 자동으로 설정 */
+.allDietPage_list_container {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
 }
 
-.ADPitemImageContainer {
-    width: 100%;
-    height: auto;
-    overflow: hidden; /* 이미지를 카드 안에 맞게 조정 */
+/* 아이템 카드 */
+.allDietPage_item_card {
+    width: calc(50% - 7.5px);
+    height: 280px;
+    border-radius: 16px;
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: none;
+    position: relative;
+    background: white;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.ADPitemImage {
+.allDietPage_item_card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+}
+
+/* 이미지 컨테이너 */
+.allDietPage_item_image_container {
     width: 100%;
-    height: auto;
+    height: 200px;
+    overflow: hidden;
+    background-color: #f8f9fa;
+    position: relative;
+}
+
+.allDietPage_item_image {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
+    transition: transform 0.3s ease;
 }
 
-.ADPitemMeta {
-    text-align: center;
+.allDietPage_item_card:hover .allDietPage_item_image {
+    transform: scale(1.05);
 }
 
-.ADPitemTitle {
-    font-size: 16px; /* 폰트 크기를 조금 키움 */
-    white-space: normal; /* 텍스트가 줄바꿈 되도록 설정 */
-    overflow: hidden; /* 넘치는 텍스트 숨김 */
-    word-wrap: break-word; /* 긴 단어를 다음 줄로 이동 */
-    word-break: keep-all; /* 공백 단위로 줄바꿈 설정 */
+/* 카테고리 태그 */
+.allDietPage_category_tag {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    background: white;
+    color: #333;
+    padding: 6px 12px;
+    border-radius: 16px;
+    font-size: 11px;
+    font-weight: 700;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* 아이템 메타 정보 */
+.allDietPage_item_meta {
+    height: 80px;
+    padding: 24px;
+    background: white;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.allDietPage_item_title {
+    font-size: 18px;
+    font-weight: 700;
+    color: #333;
+    margin-bottom: 8px;
+    letter-spacing: -0.4px;
+    line-height: 1.2;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+}
+
+.allDietPage_item_description {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 16px;
+    line-height: 1.5;
+    letter-spacing: -0.1px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+}
+
+.allDietPage_item_nutrition {
+    display: flex;
+    gap: 12px;
+}
+
+.allDietPage_calories,
+.allDietPage_protein {
+    background: rgba(157, 146, 116, 0.1);
+    color: #9d9274;
+    padding: 6px 12px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: -0.1px;
+}
+
+/* 빈 카드 (레이아웃 유지용) */
+.allDietPage_empty_card {
+    width: calc(50% - 7.5px);
+    height: 280px;
+    visibility: hidden;
+}
+
+/* 슬라이드 컨트롤 컨테이너 */
+.allDietPage_slide_controls {
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 8px 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* 슬라이드 네비게이션 버튼 */
+.allDietPage_nav_button {
+    background: transparent;
+    color: #666;
+    border: none;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+    font-size: 14px;
+}
+
+.allDietPage_nav_button:hover {
+    background: rgba(0, 0, 0, 0.1);
+    color: #333;
+}
+
+.allDietPage_nav_button:disabled {
+    color: #ccc;
+    cursor: not-allowed;
+}
+
+/* 페이지 인디케이터 */
+.allDietPage_indicators {
+    display: flex;
+    gap: 6px;
+}
+
+.allDietPage_indicator {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #ddd;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.allDietPage_indicator:hover {
+    background: #999;
+}
+
+.allDietPage_indicator.active {
+    background: #333;
+    width: 18px;
+    border-radius: 3px;
+}
+
+/* Ant Design Card 스타일 오버라이드 */
+.allDietPage_item_card .ant-card-body {
+    padding: 0;
+    height: 80px;
+}
+
+.allDietPage_item_card .ant-card-meta-title {
+    margin-bottom: 2px;
+    font-size: 14px;
+}
+
+.allDietPage_item_card .ant-card-meta-description {
+    font-size: 12px;
+    margin-bottom: 0;
 }

--- a/Front/src/pages/AllDietPage.jsx
+++ b/Front/src/pages/AllDietPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, Spin } from 'antd';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 import '../CSS/AllDietPage.css';
 import Header from '../components/Header';
 import BottomNav from '../components/BottomNav';
@@ -9,6 +10,7 @@ const { Meta } = Card;
 
 function AllDietPage() {
     const navigate = useNavigate();
+    const [currentPage, setCurrentPage] = useState(0);
 
     const handleItemClick = (item) => {
         navigate(`/dietinfo`, { state: { item } });
@@ -17,16 +19,172 @@ function AllDietPage() {
     const [mealData, setMealData] = useState([]);
     const [loading, setLoading] = useState(true);
 
+    // 예시 데이터
+    const mockData = [
+        {
+            id: 1,
+            name: "불고기 정식",
+            price: "12,000원",
+            image: "https://images.unsplash.com/photo-1546833999-b9f581a1996d?w=400&h=300&fit=crop",
+            category: "한식",
+            description: "구운 소고기, 쌀밥, 김치, 된장국",
+            calories: "580kcal",
+            protein: "단백질 42g"
+        },
+        {
+            id: 2,
+            name: "김치찌개",
+            price: "8,500원",
+            image: "https://images.unsplash.com/photo-1582049165295-cb3e3d86c1c6?w=400&h=300&fit=crop",
+            category: "한식",
+            description: "김치, 돼지고기, 두부, 쌀밥",
+            calories: "420kcal",
+            protein: "단백질 28g"
+        },
+        {
+            id: 3,
+            name: "스파게티 카르보나라",
+            price: "15,000원",
+            image: "https://images.unsplash.com/photo-1551892374-ecf8754cf8b0?w=400&h=300&fit=crop",
+            category: "양식",
+            description: "파스타, 베이컨, 달걀, 파마산 치즈",
+            calories: "650kcal",
+            protein: "단백질 35g"
+        },
+        {
+            id: 4,
+            name: "초밥 세트",
+            price: "18,000원",
+            image: "https://images.unsplash.com/photo-1579584425555-c3ce17fd4351?w=400&h=300&fit=crop",
+            category: "일식",
+            description: "연어, 참치, 새우, 간장, 와사비",
+            calories: "520kcal",
+            protein: "단백질 45g"
+        },
+        {
+            id: 5,
+            name: "치킨 샐러드",
+            price: "11,000원",
+            image: "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?w=400&h=300&fit=crop",
+            category: "샐러드",
+            description: "그릴드 치킨, 퀴노아, 아보카도, 견과류",
+            calories: "480kcal",
+            protein: "단백질 35g"
+        },
+        {
+            id: 6,
+            name: "마르게리타 피자",
+            price: "16,000원",
+            image: "https://images.unsplash.com/photo-1565299624946-b28f40a0ca4b?w=400&h=300&fit=crop",
+            category: "양식",
+            description: "토마토 소스, 모짜렐라, 바질",
+            calories: "720kcal",
+            protein: "단백질 32g"
+        },
+        {
+            id: 7,
+            name: "비빔밥",
+            price: "9,000원",
+            image: "https://images.unsplash.com/photo-1553978297-833d09932d77?w=400&h=300&fit=crop",
+            category: "한식",
+            description: "나물, 쌀밥, 고추장, 계란",
+            calories: "450kcal",
+            protein: "단백질 18g"
+        },
+        {
+            id: 8,
+            name: "새우볶음밥",
+            price: "10,500원",
+            image: "https://images.unsplash.com/photo-1603133872878-684f208fb84b?w=400&h=300&fit=crop",
+            category: "중식",
+            description: "새우, 쌀밥, 달걀, 채소",
+            calories: "520kcal",
+            protein: "단백질 26g"
+        },
+        {
+            id: 9,
+            name: "연어 스테이크",
+            price: "22,000원",
+            image: "https://images.unsplash.com/photo-1467003909585-2f8a72700288?w=400&h=300&fit=crop",
+            category: "양식",
+            description: "그릴드 연어, 아스파라거스, 레몬",
+            calories: "380kcal",
+            protein: "단백질 48g"
+        },
+        {
+            id: 10,
+            name: "된장찌개",
+            price: "7,500원",
+            image: "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=400&h=300&fit=crop",
+            category: "한식",
+            description: "된장, 두부, 파, 쌀밥",
+            calories: "380kcal",
+            protein: "단백질 22g"
+        },
+        {
+            id: 11,
+            name: "팟타이",
+            price: "13,000원",
+            image: "https://images.unsplash.com/photo-1559847844-d0c8655b8ea6?w=400&h=300&fit=crop",
+            category: "아시아",
+            description: "쌀국수, 새우, 땅콩, 숙주",
+            calories: "540kcal",
+            protein: "단백질 30g"
+        },
+        {
+            id: 12,
+            name: "치킨 버거",
+            price: "8,000원",
+            image: "https://images.unsplash.com/photo-1568901346375-23c9450c58cd?w=400&h=300&fit=crop",
+            category: "패스트푸드",
+            description: "치킨 패티, 양상추, 토마토, 감자튀김",
+            calories: "680kcal",
+            protein: "단백질 38g"
+        }
+    ];
+
+    // 슬라이드 기능을 위한 설정
+    const itemsPerPage = 10;
+    const totalPages = Math.ceil(mealData.length / itemsPerPage);
+    const showSlideControls = mealData.length > 10;
+
+    const getCurrentPageItems = () => {
+        if (!showSlideControls) return mealData;
+        
+        const startIndex = currentPage * itemsPerPage;
+        const endIndex = startIndex + itemsPerPage;
+        return mealData.slice(startIndex, endIndex);
+    };
+
+    const nextPage = () => {
+        if (currentPage < totalPages - 1) {
+            setCurrentPage(currentPage + 1);
+        }
+    };
+
+    const prevPage = () => {
+        if (currentPage > 0) {
+            setCurrentPage(currentPage - 1);
+        }
+    };
+
+    const goToPage = (pageIndex) => {
+        setCurrentPage(pageIndex);
+    };
+
     useEffect(() => {
         const handleGet = async () => {
             try {
+                setLoading(true);
+                
+                // 실제 API 호출 (주석 처리)
+                /*
                 const token = localStorage.getItem("token");
-
                 const response = await fetch(`http://3.37.64.39:8000/api/meal/food`, {
                     method: "GET",
                     headers: {
                         "Content-Type": "application/json",
-                        "Authorization":  token, // Bearer 토큰 형식으로 변경
+                        "Authorization": token,
                     }
                 });
 
@@ -40,45 +198,110 @@ function AllDietPage() {
 
                 if (response.ok) {
                     setMealData(result);
-                    //console.log(result);
                 } else {
                     console.log("실패");
                     alert("실패: " + result.message);
                 }
+                */
+
+                // 목 데이터 사용 (개발용)
+                setTimeout(() => {
+                    setMealData(mockData);
+                    setLoading(false);
+                }, 1000);
+
             } catch (error) {
                 console.error("Error fetching data:", error);
                 alert("데이터를 가져오는 중 오류가 발생했습니다.");
-            } finally {
-                setLoading(false); // 데이터 로딩이 완료되면 로딩 상태를 false로 설정
+                setLoading(false);
             }
         };
         handleGet();
     }, []);
 
     if (loading) {
-        return <div style={{width: "100%", height: "100%", display: 'flex', alignItems: "center", justifyContent: 'center'}}><Spin size="large" /></div>;
+        return (
+            <div className="allDietPage_loading_container">
+                <Spin size="large" />
+            </div>
+        );
     }
 
     return (
         <>
             <Header />
 
-            <div className="ADPcontainer">
-                <div className="ADPlistContainer">
-                    {mealData.map((item, index) => (
+            <div className="allDietPage_container">
+                <div className="allDietPage_list_container">
+                    {getCurrentPageItems().map((item, index) => (
                         <Card
-                            key={index}
+                            key={item.id}
                             hoverable
-                            className="ADPitemCard"
+                            className="allDietPage_item_card"
                             onClick={() => handleItemClick(item)}
+                            cover={
+                                <div className="allDietPage_item_image_container">
+                                    <img 
+                                        src={item.image} 
+                                        alt={item.name} 
+                                        className="allDietPage_item_image" 
+                                    />
+                                    <div className="allDietPage_category_tag">{item.category}</div>
+                                </div>
+                            }
                         >
-                            <div className="ADPitemImageContainer">
-                                <img src={item.image} alt={item.name} className="ADPitemImage" />
+                            <div className="allDietPage_item_meta">
+                                <div className="allDietPage_item_title">{item.name}</div>
+                                <div className="allDietPage_item_description">{item.description}</div>
+                                <div className="allDietPage_item_nutrition">
+                                    <span className="allDietPage_calories">{item.calories}</span>
+                                    <span className="allDietPage_protein">{item.protein}</span>
+                                </div>
                             </div>
-                            <Meta title={<div className="ADPitemTitle">{item.name}</div>} description={`가격: ${item.price}`} className="ADPitemMeta" />
                         </Card>
                     ))}
+                    
+                    {/* 빈 공간 채우기 (10개 미만일 때) */}
+                    {getCurrentPageItems().length < 10 && 
+                        Array.from({ length: 10 - getCurrentPageItems().length }, (_, index) => (
+                            <div key={`empty-${index}`} className="allDietPage_empty_card"></div>
+                        ))
+                    }
                 </div>
+
+                {/* 슬라이드 컨트롤 (10개 이상일 때만 표시) */}
+                {showSlideControls && (
+                    <div className="allDietPage_slide_controls">
+                        {/* 왼쪽: 이전 버튼 */}
+                        <button 
+                            className="allDietPage_nav_button allDietPage_prev_button"
+                            onClick={prevPage}
+                            disabled={currentPage === 0}
+                        >
+                            <LeftOutlined />
+                        </button>
+
+                        {/* 가운데: 페이지 인디케이터 */}
+                        <div className="allDietPage_indicators">
+                            {Array.from({ length: totalPages }, (_, index) => (
+                                <div
+                                    key={index}
+                                    className={`allDietPage_indicator ${index === currentPage ? 'active' : ''}`}
+                                    onClick={() => goToPage(index)}
+                                />
+                            ))}
+                        </div>
+
+                        {/* 오른쪽: 다음 버튼 */}
+                        <button 
+                            className="allDietPage_nav_button allDietPage_next_button"
+                            onClick={nextPage}
+                            disabled={currentPage === totalPages - 1}
+                        >
+                            <RightOutlined />
+                        </button>
+                    </div>
+                )}
             </div>
 
             <BottomNav />

--- a/Front/src/pages/AllDietPage.jsx
+++ b/Front/src/pages/AllDietPage.jsx
@@ -1,52 +1,76 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Card, Spin } from 'antd';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
 import '../CSS/AllDietPage.css';
 import Header from '../components/Header';
 import BottomNav from '../components/BottomNav';
-
-const { Meta } = Card;
+import cat from '../images/cat2.png';
 
 function AllDietPage() {
     const navigate = useNavigate();
     const [currentPage, setCurrentPage] = useState(0);
+    const [isAnimating, setIsAnimating] = useState(false);
+    const [animationClass, setAnimationClass] = useState('');
 
     const handleItemClick = (item) => {
         navigate(`/dietinfo`, { state: { item } });
     };
 
+
     const [mealData, setMealData] = useState([]);
     const [loading, setLoading] = useState(true);
+
+    const animatePageTransition = (direction, callback) => {
+        if (isAnimating) return;
+        
+        setIsAnimating(true);
+        
+        const outClass = direction === 'next' ? 'slide-out-left' : 'slide-out-right';
+        setAnimationClass(outClass);
+        
+        setTimeout(() => {
+            callback();
+            const inClass = direction === 'next' ? 'slide-in-right' : 'slide-in-left';
+            setAnimationClass(inClass);
+            
+            setTimeout(() => {
+                setAnimationClass('slide-in-center');
+                setTimeout(() => {
+                    setAnimationClass('');
+                    setIsAnimating(false);
+                }, 500);
+            }, 50);
+        }, 250);
+    };
 
     // 예시 데이터
     const mockData = [
         {
             id: 1,
-            name: "불고기 정식",
+            name: "건강한 아침 정식",
             price: "12,000원",
-            image: "https://images.unsplash.com/photo-1546833999-b9f581a1996d?w=400&h=300&fit=crop",
-            category: "한식",
-            description: "구운 소고기, 쌀밥, 김치, 된장국",
-            calories: "580kcal",
-            protein: "단백질 42g"
+            image: cat,
+            category: "아침",
+            description: "현미밥, 된장찌개, 김치, 시금치나물",
+            calories: "520kcal",
+            protein: "단백질 18g"
         },
         {
             id: 2,
-            name: "김치찌개",
+            name: "프로틴 파워볼",
             price: "8,500원",
-            image: "https://images.unsplash.com/photo-1582049165295-cb3e3d86c1c6?w=400&h=300&fit=crop",
-            category: "한식",
-            description: "김치, 돼지고기, 두부, 쌀밥",
-            calories: "420kcal",
-            protein: "단백질 28g"
+            image: cat,
+            category: "점심",
+            description: "그릴드 치킨, 퀴노아, 아보카도, 견과류",
+            calories: "480kcal",
+            protein: "단백질 35g"
         },
         {
             id: 3,
             name: "스파게티 카르보나라",
             price: "15,000원",
-            image: "https://images.unsplash.com/photo-1551892374-ecf8754cf8b0?w=400&h=300&fit=crop",
-            category: "양식",
+            image: cat,
+            category: "저녁",
             description: "파스타, 베이컨, 달걀, 파마산 치즈",
             calories: "650kcal",
             protein: "단백질 35g"
@@ -55,28 +79,28 @@ function AllDietPage() {
             id: 4,
             name: "초밥 세트",
             price: "18,000원",
-            image: "https://images.unsplash.com/photo-1579584425555-c3ce17fd4351?w=400&h=300&fit=crop",
-            category: "일식",
+            image: cat,
+            category: "저녁",
             description: "연어, 참치, 새우, 간장, 와사비",
             calories: "520kcal",
             protein: "단백질 45g"
         },
         {
             id: 5,
-            name: "치킨 샐러드",
+            name: "치킨 샐러드 볼",
             price: "11,000원",
-            image: "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?w=400&h=300&fit=crop",
-            category: "샐러드",
-            description: "그릴드 치킨, 퀴노아, 아보카도, 견과류",
-            calories: "480kcal",
-            protein: "단백질 35g"
+            image: cat,            
+            category: "점심",
+            description: "그릴드 치킨, 아보카도, 견과류, 방울토마토",
+            calories: "420kcal",
+            protein: "단백질 32g"
         },
         {
             id: 6,
             name: "마르게리타 피자",
             price: "16,000원",
-            image: "https://images.unsplash.com/photo-1565299624946-b28f40a0ca4b?w=400&h=300&fit=crop",
-            category: "양식",
+            image: cat,            
+            category: "저녁",
             description: "토마토 소스, 모짜렐라, 바질",
             calories: "720kcal",
             protein: "단백질 32g"
@@ -85,8 +109,8 @@ function AllDietPage() {
             id: 7,
             name: "비빔밥",
             price: "9,000원",
-            image: "https://images.unsplash.com/photo-1553978297-833d09932d77?w=400&h=300&fit=crop",
-            category: "한식",
+            image: cat,            
+            category: "점심",
             description: "나물, 쌀밥, 고추장, 계란",
             calories: "450kcal",
             protein: "단백질 18g"
@@ -95,8 +119,8 @@ function AllDietPage() {
             id: 8,
             name: "새우볶음밥",
             price: "10,500원",
-            image: "https://images.unsplash.com/photo-1603133872878-684f208fb84b?w=400&h=300&fit=crop",
-            category: "중식",
+            image: cat,            
+            category: "점심",
             description: "새우, 쌀밥, 달걀, 채소",
             calories: "520kcal",
             protein: "단백질 26g"
@@ -105,8 +129,8 @@ function AllDietPage() {
             id: 9,
             name: "연어 스테이크",
             price: "22,000원",
-            image: "https://images.unsplash.com/photo-1467003909585-2f8a72700288?w=400&h=300&fit=crop",
-            category: "양식",
+            image: cat,            
+            category: "저녁",
             description: "그릴드 연어, 아스파라거스, 레몬",
             calories: "380kcal",
             protein: "단백질 48g"
@@ -115,38 +139,18 @@ function AllDietPage() {
             id: 10,
             name: "된장찌개",
             price: "7,500원",
-            image: "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=400&h=300&fit=crop",
-            category: "한식",
+            image: cat,            
+            category: "점심",
             description: "된장, 두부, 파, 쌀밥",
             calories: "380kcal",
             protein: "단백질 22g"
-        },
-        {
-            id: 11,
-            name: "팟타이",
-            price: "13,000원",
-            image: "https://images.unsplash.com/photo-1559847844-d0c8655b8ea6?w=400&h=300&fit=crop",
-            category: "아시아",
-            description: "쌀국수, 새우, 땅콩, 숙주",
-            calories: "540kcal",
-            protein: "단백질 30g"
-        },
-        {
-            id: 12,
-            name: "치킨 버거",
-            price: "8,000원",
-            image: "https://images.unsplash.com/photo-1568901346375-23c9450c58cd?w=400&h=300&fit=crop",
-            category: "패스트푸드",
-            description: "치킨 패티, 양상추, 토마토, 감자튀김",
-            calories: "680kcal",
-            protein: "단백질 38g"
         }
     ];
 
     // 슬라이드 기능을 위한 설정
-    const itemsPerPage = 10;
+    const itemsPerPage = 4; 
     const totalPages = Math.ceil(mealData.length / itemsPerPage);
-    const showSlideControls = mealData.length > 10;
+    const showSlideControls = mealData.length > 4;
 
     const getCurrentPageItems = () => {
         if (!showSlideControls) return mealData;
@@ -222,57 +226,53 @@ function AllDietPage() {
     if (loading) {
         return (
             <div className="allDietPage_loading_container">
-                <Spin size="large" />
+                <div className="allDietPage_loading_spinner"></div>
+                <p className="allDietPage_loading_spinner_text">영양 데이터를 불러오는 중...</p>
             </div>
         );
     }
+
+    const currentItem = mealData[currentPage];
 
     return (
         <>
             <Header />
 
             <div className="allDietPage_container">
-                <div className="allDietPage_list_container">
-                    {getCurrentPageItems().map((item, index) => (
-                        <Card
-                            key={item.id}
-                            hoverable
-                            className="allDietPage_item_card"
-                            onClick={() => handleItemClick(item)}
-                            cover={
-                                <div className="allDietPage_item_image_container">
-                                    <img 
-                                        src={item.image} 
-                                        alt={item.name} 
-                                        className="allDietPage_item_image" 
-                                    />
-                                    <div className="allDietPage_category_tag">{item.category}</div>
+                <div className="allDietPage_meals_grid">
+                    {getCurrentPageItems().map((item) => (
+                        <div key={item.id} className="allDietPage_meal_card" onClick={() => handleItemClick(item)}>
+                            <div className="allDietPage_meal_time">
+                                <span className="allDietPage_time_label">{item.category}</span>
+                            </div>
+                            <div className="allDietPage_meal_image">
+                                <img src={item.image} alt={item.name} className="allDietPage_meal_image_content"/>
+                            </div>
+                            <div className="allDietPage_meal_info">
+                                <h3 className="allDietPage_meal_info_name">{item.name}</h3>
+                                <p className="allDietPage_meal_info_description">{item.description}</p>
+                                <div className="allDietPage_nutrition_info">
+                                    <span className="allDietPage_nutrition_info1">{item.calories}</span>
+                                    <span className="allDietPage_nutrition_info2">{item.protein}</span>
                                 </div>
-                            }
-                        >
-                            <div className="allDietPage_item_meta">
-                                <div className="allDietPage_item_title">{item.name}</div>
-                                <div className="allDietPage_item_description">{item.description}</div>
-                                <div className="allDietPage_item_nutrition">
-                                    <span className="allDietPage_calories">{item.calories}</span>
-                                    <span className="allDietPage_protein">{item.protein}</span>
+                                <div className="allDietPage_price_info">
+                                    <span className="allDietPage_price">{item.price}</span>
                                 </div>
                             </div>
-                        </Card>
+                        </div>
                     ))}
                     
-                    {/* 빈 공간 채우기 (10개 미만일 때) */}
-                    {getCurrentPageItems().length < 10 && 
-                        Array.from({ length: 10 - getCurrentPageItems().length }, (_, index) => (
+                    {/* 빈 공간 채우기 (8개 미만일 때) */}
+                    {getCurrentPageItems().length < 8 && 
+                        Array.from({ length: 8 - getCurrentPageItems().length }, (_, index) => (
                             <div key={`empty-${index}`} className="allDietPage_empty_card"></div>
                         ))
                     }
                 </div>
 
-                {/* 슬라이드 컨트롤 (10개 이상일 때만 표시) */}
+                
                 {showSlideControls && (
                     <div className="allDietPage_slide_controls">
-                        {/* 왼쪽: 이전 버튼 */}
                         <button 
                             className="allDietPage_nav_button allDietPage_prev_button"
                             onClick={prevPage}
@@ -281,7 +281,6 @@ function AllDietPage() {
                             <LeftOutlined />
                         </button>
 
-                        {/* 가운데: 페이지 인디케이터 */}
                         <div className="allDietPage_indicators">
                             {Array.from({ length: totalPages }, (_, index) => (
                                 <div
@@ -292,7 +291,6 @@ function AllDietPage() {
                             ))}
                         </div>
 
-                        {/* 오른쪽: 다음 버튼 */}
                         <button 
                             className="allDietPage_nav_button allDietPage_next_button"
                             onClick={nextPage}


### PR DESCRIPTION
## 📝 작업 내용
- 식단 전체 구성을 메인페이지와 동일한 형태의 카드로 2열 2행으로 구성
- 4개이상 넘어가면 좌우로 슬라이드 구현
- 이미지는 임시로 cat 활용

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #7

## 💬 추가 요청사항

## ✅ 체크리스트
### 코드 품질
- [x] 커밋 컨벤션 준수 (feat/fix/docs/refactor 등)
- [x] 불필요한 코드/주석 제거

### 테스트
- [x] 로컬 환경에서 동작 확인 완료
- [x] 기존 기능에 영향 없음 확인

### 리뷰
- [x] 적절한 리뷰어 지정 완료
- [x] 리뷰어 1명 이상 승인
<img width="399" alt="스크린샷 2025-06-10 오후 3 17 36" src="https://github.com/user-attachments/assets/a198d0da-1061-477d-820a-df84817d30be" />
<img width="398" alt="스크린샷 2025-06-10 오후 3 17 45" src="https://github.com/user-attachments/assets/fb65f544-7757-4eb2-b410-28190b4d0c54" />

