### PR TITLE
design: 전체식단페이지 카드 수정, 식단 상세페이지 디자인 변경(#64)

### DIFF
--- a/Front/src/CSS/AllDietPage.css
+++ b/Front/src/CSS/AllDietPage.css
@@ -37,27 +37,20 @@
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    padding: 20px 24px 120px 24px;
+    padding: 20px 24px 55px 24px;
     position: relative;
-    height: calc(100vh - 130px);
+    height: 75vh;
 
 }
 
-/* 식단 그리드 */
+/* 식단 컨테이너 - 그리드 제거 */
 .allDietPage_meals_grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(2, minmax(180px, 1fr)); 
-    gap: 20px;
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    margin: 0 auto;
-    transition: all 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    opacity: 1;
-    transform: translateX(0);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    overflow: hidden;
+    overflow-y: auto;
 }
-
 
 /* 메인 카드 */
 .allDietPage_meal_card {
@@ -67,8 +60,10 @@
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
     transition: all 0.3s ease;
     position: relative;
-    width: 100%;
+    width: calc(50% - 8px);
+    height: 300px;
     cursor: pointer;
+    margin-bottom: 8px;
 }
 
 .allDietPage_meal_card:hover {
@@ -76,12 +71,6 @@
     box-shadow: 0 12px 36px rgba(0, 0, 0, 0.12);
 }
 
-/* 빈 카드 */
-.allDietPage_empty_card {
-    width: 100%;
-    height: 100%;
-    visibility: hidden;
-}
 
 /* 시간 태그 */
 .allDietPage_meal_time {
@@ -105,7 +94,7 @@
 
 /* 이미지 */
 .allDietPage_meal_image {
-    height: 40%;
+    height: 45%;
     overflow: hidden;
     position: relative;
 }
@@ -123,48 +112,51 @@
 
 /* 정보 영역 */
 .allDietPage_meal_info {
-    padding: 18px;
+    padding: 16px;
     background: white;
-    height: 40%;
+    height: 55%;
     display: flex;
     flex-direction: column;
+    position: relative;
 }
 
 .allDietPage_meal_info_name {
-    font-size: 17px;
+    font-size: 16px;
     font-weight: 700;
     color: #333;
-    margin-bottom: 4px;
     letter-spacing: -0.3px;
-    overflow: hidden;
-    -webkit-box-orient: vertical;
     line-height: 1.2;
+    height: 40px;
+    overflow: hidden;
+
 }
 
 .allDietPage_meal_info_description {
-    font-size: 13px;
+    font-size: 12px;
     color: #666;
-    margin-bottom: 12px;
     line-height: 1.3;
     letter-spacing: -0.1px;
-    overflow: hidden;
 }
 
 /* 영양 정보 */
 .allDietPage_nutrition_info {
     display: flex;
-    gap: 8px;
-    margin-top: auto;
-    margin-bottom: 8px;
+    gap: 6px;
+    height: 20px;
+    align-items: center;
+    position: absolute;
+    bottom: 80px;
+    left: 16px;
+    right: 16px;
 }
 
 .allDietPage_nutrition_info1,
 .allDietPage_nutrition_info2 {
     background: #9d9274;
     color: white;
-    padding: 4px 8px;
-    border-radius: 10px;
-    font-size: 10px;
+    padding: 3px 6px;
+    border-radius: 8px;
+    font-size: 9px;
     font-weight: 600;
     letter-spacing: -0.1px;
     white-space: nowrap;
@@ -173,19 +165,22 @@
 /* 가격 정보 */
 .allDietPage_price_info {
     display: flex;
-    justify-content: flex-end;
-    margin-top: 4px;
-    
+    justify-content: center;
+    position: absolute;
+    bottom: 43px;
+    left: 16px;
+    right: 16px;
+    height: 28px;
 }
 
 .allDietPage_price {
     background: linear-gradient(135deg, #ff6b6b 0%, #ff8e53 100%);
     color: white;
-    padding: 8px 12px;
-    border-radius: 12px;
+    padding: 6px 10px;
+    border-radius: 10px;
     width: 100%;
     text-align: center;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 800;
     letter-spacing: -0.2px;
     box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
@@ -196,7 +191,7 @@
 
 .allDietPage_price::before {
     content: '₩';
-    font-size: 11px;
+    font-size: 10px;
     margin-right: 2px;
     opacity: 0.9;
 }

--- a/Front/src/CSS/DietInfoPage.css
+++ b/Front/src/CSS/DietInfoPage.css
@@ -1,177 +1,183 @@
-.DIPcontainer {
+.dietInfoPage_container {
     display: flex;
     justify-content: center;
-    align-items: center;
     width: 100%;
-
-    box-sizing: border-box;
-
-}
-
-.DIPlistContainer {
-    margin-top: 5px;
-    height: 84vh;
-    width: 90%; /* Adjusted width */
-    background-color: white;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 그림자 추가 */
-    border-radius: 15px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
+    padding: 20px;
     box-sizing: border-box;
 }
 
-.DIPimageContainer {
-    width: 100%; /* Adjust the width as needed */
-    display: flex;
-    justify-content: center;
-    margin-top: -10px; /* Move image upwards */
-
-}
-
-.DIPtitleImage {
-    width: 50%; /* Adjust the width to make the image smaller */
-    max-width: 300px; /* Add a max-width to prevent it from being too large */
-    border-radius: 15px;
-
-}
-
-.DIPtitle {
-    text-align: center;
-    font-size: 20px; /* Adjusted font size */
-    margin-top: 5px; /* Reduced top margin */
-    margin-bottom: 5px; /* Reduced bottom margin */
-}
-
-.DIPsectionTitle{
-    margin-top: -20px;
-}
-
-.DIPdescription {
-    text-align: center;
-    font-size: 14px; /* Adjusted font size */
-    color: #666;
-
-}
-
-.DIPmenu, .DIPnutrient {
+.dietInfoPage_card {
     width: 100%;
-
+    max-width: 400px;
+    background: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.DIPnutrient {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-}
-
-.nutrientListContainer {
+/* 이미지 섹션 */
+.dietInfoPage_imageSection {
     width: 100%;
-    max-width: 600px;
-    background-color: white;
-    border-radius: 15px;
+    height: 240px;
+    overflow: hidden;
+}
+
+.dietInfoPage_image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* 헤더 */
+.dietInfoPage_header {
+    padding: 20px;
+    text-align: center;
+    border-bottom: 1px solid #eee;
+}
+
+.dietInfoPage_title {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 600;
+    color: #333;
+}
+
+/* 섹션 */
+.dietInfoPage_section {
+    padding: 20px;
+    border-bottom: 1px solid #eee;
+}
+
+.dietInfoPage_sectionTitle {
+    margin: 0 0 16px 0;
+    font-size: 16px;
+    font-weight: 600;
+
+}
+
+/* 메뉴 리스트 */
+.dietInfoPage_menuList {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    gap: 12px;
 }
 
-.nutrientList {
+.dietInfoPage_menuGroup {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
+    align-items: flex-start;
+    gap: 12px;
 }
 
-.nutrientItem {
-    padding: 5px;
-    border-radius: 10px;
+.dietInfoPage_menuType {
+    min-width: 60px;
+    padding: 4px 8px;
+    background-color: #9d9274;
+    color: white;
+    border-radius: 4px;
     font-size: 14px;
+    font-weight: 500;
     text-align: center;
-    margin: 5px;
+}
+
+.dietInfoPage_items {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
     flex: 1;
-    min-width: 80px;
 }
 
-/* 각 영양소의 선 색상 적용 */
-.nutrientItem.carbohydrates {
-    border: 1px solid #ff7f50; /* 코랄 색상 */
+.dietInfoPage_items span {
+    font-size: 14px;
+    color: #333;
+    line-height: 1.4;
 }
 
-.nutrientItem.protein {
-    border: 1px solid #4682b4; /* 스틸 블루 색상 */
+/* 영양성분 그리드 */
+.dietInfoPage_nutritionGrid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
 }
 
-.nutrientItem.fat {
-    border: 1px solid #32cd32; /* 라임 그린 색상 */
-}
-
-.nutrientItem.sugar {
-    border: 1px solid #da70d6; /* 오키드 색상 */
-}
-
-.nutrientItem.sodium {
-    border: 1px solid #ff4500; /* 오렌지 레드 색상 */
-}
-
-.DIPfooter {
-    width: 100%;
+.dietInfoPage_nutritionItem {
     display: flex;
     justify-content: space-between;
     align-items: center;
-
+    padding: 12px;
+    background-color: #f8f8f8;
+    border-radius: 4px;
+    border-left: 3px solid #9d9274;
 }
 
-.DIPcalories, .DIPprice {
+.dietInfoPage_nutritionItem:nth-child(1) {
+    border-left-color: #ff7f50; /* 탄수화물 - 코랄 */
+}
+
+.dietInfoPage_nutritionItem:nth-child(2) {
+    border-left-color: #4682b4; /* 단백질 - 스틸블루 */
+}
+
+.dietInfoPage_nutritionItem:nth-child(3) {
+    border-left-color: #32cd32; /* 지방 - 라임그린 */
+}
+
+.dietInfoPage_nutritionItem:nth-child(4) {
+    border-left-color: #da70d6; /* 당류 - 오키드 */
+}
+
+.dietInfoPage_nutritionItem:nth-child(5) {
+    border-left-color: #ff4500; /* 나트륨 - 오렌지레드 */
+}
+
+.dietInfoPage_nutritionLabel {
+    font-size: 14px;
+    color: #666;
+}
+
+.dietInfoPage_nutritionValue {
+    font-size: 14px;
     font-weight: 600;
-    font-size: 14px; /* Adjusted font size */
+    color: #333;
 }
 
-.DIPsectionTitle {
-    font-weight: bold;
-    font-size: 16px; /* Adjusted font size */
-    margin-bottom: 5px; /* Reduced margin */
-    display: block;
+/* 푸터 */
+.dietInfoPage_footer {
+    display: flex;
+    padding: 20px;
+    background-color: #9d9274;
 }
 
-/* 칼로리 강조를 위한 애니메이션 효과 */
-.calories-icon-left, .calories-icon-right {
-    font-size: 24px; /* 아이콘 크기 */
-    animation: bounce 2s infinite; /* 애니메이션 효과 */
-    position: relative;
+.dietInfoPage_info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
 }
 
-.calories-icon-left {
-    margin-right: -50px;
+.dietInfoPage_info:first-child {
+    border-right: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-.calories-icon-right {
-    margin-left: -50px;
+.dietInfoPage_label {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.8);
+    font-weight: 500;
 }
 
-/* 애니메이션 효과 정의 */
-@keyframes bounce {
-    0%, 20%, 50%, 80%, 100% {
-        transform: translateY(0);
+.dietInfoPage_value {
+    font-size: 18px;
+    font-weight: 600;
+    color: white;
+}
+
+/* 반응형 */
+@media (max-width: 480px) {
+    .dietInfoPage_container {
+        padding: 12px;
     }
-    40% {
-        transform: translateY(-10px);
-    }
-    60% {
-        transform: translateY(-5px);
-    }
-}
-
-.DIPcalories {
-    animation: bounce 2s infinite; /* 깜빡이는 애니메이션 적용 */
-}
-
-/* 깜빡이는 애니메이션 정의 */
-@keyframes blink-red {
-    0%, 100% {
-        color: black;
-    }
-    50% {
-        color: red;
+    
+    .dietInfoPage_nutritionGrid {
+        grid-template-columns: 1fr;
     }
 }
-

--- a/Front/src/pages/AllDietPage.jsx
+++ b/Front/src/pages/AllDietPage.jsx
@@ -18,28 +18,7 @@ function AllDietPage() {
     const [mealData, setMealData] = useState([]);
     const [loading, setLoading] = useState(true);
 
-    const animatePageTransition = (direction, callback) => {
-        if (isAnimating) return;
-        
-        setIsAnimating(true);
-        
-        const outClass = direction === 'next' ? 'slide-out-left' : 'slide-out-right';
-        setAnimationClass(outClass);
-        
-        setTimeout(() => {
-            callback();
-            const inClass = direction === 'next' ? 'slide-in-right' : 'slide-in-left';
-            setAnimationClass(inClass);
-            
-            setTimeout(() => {
-                setAnimationClass('slide-in-center');
-                setTimeout(() => {
-                    setAnimationClass('');
-                    setIsAnimating(false);
-                }, 500);
-            }, 50);
-        }, 250);
-    };
+
 
     // 예시 데이터
     const mockData = [
@@ -258,12 +237,7 @@ function AllDietPage() {
                         </div>
                     ))}
                     
-                    {/* 빈 공간 채우기 (8개 미만일 때) */}
-                    {getCurrentPageItems().length < 8 && 
-                        Array.from({ length: 8 - getCurrentPageItems().length }, (_, index) => (
-                            <div key={`empty-${index}`} className="allDietPage_empty_card"></div>
-                        ))
-                    }
+                
                 </div>
 
                 

--- a/Front/src/pages/DietInfoPage.jsx
+++ b/Front/src/pages/DietInfoPage.jsx
@@ -3,52 +3,87 @@ import { useLocation } from 'react-router-dom';
 import { Card, Typography, Divider } from 'antd';
 import '../CSS/DietInfoPage.css';
 
-
-const { Title, Paragraph } = Typography;
+const { Title, Text } = Typography;
 
 function DietInfoPage({ style }) {
     const location = useLocation();
     const { item } = location.state;
 
     return (
-        <>
-            <div className="DIPcontainer" style={style}>
-                <Card className="DIPlistContainer">
-                    <div className="DIPimageContainer">
-                    <img src={item.image} className="DIPtitleImage" alt="foodimage" />
-                    </div>
-                    <Title level={4} className="DIPtitle">{item.name}</Title>
-                   
-                    <Divider/>
-                    <Title level={4} className="DIPsectionTitle">메뉴 소개</Title>
-                    <Paragraph>메인 메뉴1: {item.main1}</Paragraph>
-                    <Paragraph>메인 메뉴2: {item.main2}</Paragraph>
-                    <Paragraph>사이드 메뉴1: {item.side1}</Paragraph>
-                    <Paragraph>사이드 메뉴2: {item.side2}</Paragraph>
-                    <Paragraph>사이드 메뉴3: {item.side3}</Paragraph>
-                    <Divider />
-                    <Title level={4} className="DIPsectionTitle">영양성분</Title>
-                    <div class="nutrientContainer">
-                        <div class="nutrientListContainer">
-                            <div class="nutrientList">
-                                <div class="nutrientItem carbohydrates">탄수화물 {item.carbohydrate}</div>
-                                <div class="nutrientItem protein">단백질 {item.protein}</div>
-                                <div class="nutrientItem fat">지방 {item.fat}</div>
-                                <div class="nutrientItem sugar">당류 {item.sugar}</div>
-                                <div class="nutrientItem sodium">나트륨 {item.sodium}</div>
+        <div className="dietInfoPage_container" style={style}>
+            <div className="dietInfoPage_card">
+                {/* 이미지 */}
+                <div className="dietInfoPage_imageSection">
+                    <img src={item.image} className="dietInfoPage_image" alt={item.name} />
+                </div>
+
+                {/* 메뉴명 */}
+                <div className="dietInfoPage_header">
+                    <h1 className="dietInfoPage_title">{item.name}</h1>
+                </div>
+
+                {/* 메뉴 구성 */}
+                <div className="dietInfoPage_section">
+                    <h3 className="dietInfoPage_sectionTitle">메뉴 구성</h3>
+                    <div className="dietInfoPage_menuList">
+                        <div className="dietInfoPage_menuGroup">
+                            <span className="dietInfoPage_menuType">메인</span>
+                            <div className="dietInfoPage_items">
+                                <span>{item.main1}</span>
+                                <span>{item.main2}</span>
+                            </div>
+                        </div>
+                        <div className="dietInfoPage_menuGroup">
+                            <span className="dietInfoPage_menuType">사이드</span>
+                            <div className="dietInfoPage_items">
+                                <span>{item.side1}</span>
+                                <span>{item.side2}</span>
+                                <span>{item.side3}</span>
                             </div>
                         </div>
                     </div>
-                    <Divider />
-                    <div className="DIPfooter">
-                    <span className="calories-icon-left">🔥</span>
-                        <div className="DIPcalories">칼로리: {item.calories}</div>
-                        <span className="calories-icon-right">🔥</span>
-                        <div className="DIPprice">가격: {item.price}</div>
+                </div>
+
+                {/* 영양성분 */}
+                <div className="dietInfoPage_section">
+                    <h3 className="dietInfoPage_sectionTitle">영양성분</h3>
+                    <div className="dietInfoPage_nutritionGrid">
+                        <div className="dietInfoPage_nutritionItem">
+                            <span className="dietInfoPage_nutritionLabel">탄수화물</span>
+                            <span className="dietInfoPage_nutritionValue">{item.carbohydrate}</span>
+                        </div>
+                        <div className="dietInfoPage_nutritionItem">
+                            <span className="dietInfoPage_nutritionLabel">단백질</span>
+                            <span className="dietInfoPage_nutritionValue">{item.protein}</span>
+                        </div>
+                        <div className="dietInfoPage_nutritionItem">
+                            <span className="dietInfoPage_nutritionLabel">지방</span>
+                            <span className="dietInfoPage_nutritionValue">{item.fat}</span>
+                        </div>
+                        <div className="dietInfoPage_nutritionItem">
+                            <span className="dietInfoPage_nutritionLabel">당류</span>
+                            <span className="dietInfoPage_nutritionValue">{item.sugar}</span>
+                        </div>
+                        <div className="dietInfoPage_nutritionItem">
+                            <span className="dietInfoPage_nutritionLabel">나트륨</span>
+                            <span className="dietInfoPage_nutritionValue">{item.sodium}</span>
+                        </div>
                     </div>
-                </Card>
+                </div>
+
+                {/* 칼로리 & 가격 */}
+                <div className="dietInfoPage_footer">
+                    <div className="dietInfoPage_info">
+                        <span className="dietInfoPage_label">칼로리</span>
+                        <span className="dietInfoPage_value">{item.calories}</span>
+                    </div>
+                    <div className="dietInfoPage_info">
+                        <span className="dietInfoPage_label">가격</span>
+                        <span className="dietInfoPage_value">{item.price}</span>
+                    </div>
+                </div>
             </div>
-        </>
+        </div>
     );
 }
 


### PR DESCRIPTION
## 📝 작업 내용
<전체식단페이지>
- 식단 카드 비율 수정 -> (컨트롤 + )눌러도 카드 비율 안 깨지게 수정(px로 고정)
- 화면 비율이 커지면 식단 카드 내부 스크롤 활성화
- CSS grid 삭제 -> wrap 사용
- 하단바랑 페이지 사이 여백 넘치는거 수정

<식단 상세페이지>
- 디자인 수정
- 세부 글자(메인메뉴,사이드 등등)는 API 연결 후 font-size 조절 예정

## 🔗 관련 이슈
- Closes #64
- Related to #59 

## 💬 추가 요청사항
없습니다.

## ✅ 체크리스트
### 코드 품질
- [x] 커밋 컨벤션 준수 (feat/fix/docs/refactor 등)
- [x] 불필요한 코드/주석 제거

### 테스트
- [x] 로컬 환경에서 동작 확인 완료
- [x] 기존 기능에 영향 없음 확인

### 리뷰
- [x] 적절한 리뷰어 지정 완료
- [x] 리뷰어 1명 이상 승인

## 작업물
<img width="398" alt="스크린샷 2025-06-11 오전 12 33 45" src="https://github.com/user-attachments/assets/c72c63f0-7306-4628-9b5e-5eb8e1763bd7" />
<img width="398" alt="스크린샷 2025-06-11 오전 12 33 35" src="https://github.com/user-attachments/assets/943b2b8a-0192-49ff-a2a0-3d5120b3a55a" />

