### PR TITLE
refactor: 외부 API Service 분리, RestTemplate Bean 중복 생성 해결(#39, #43)

### DIFF
--- a/Backend/src/main/java/com/demo/nimn/config/OpenAiConfig.java
+++ b/Backend/src/main/java/com/demo/nimn/config/OpenAiConfig.java
@@ -9,8 +9,9 @@ import org.springframework.web.client.RestTemplate;
 public class OpenAiConfig {
     @Value("${openai.api.key}")
     private String openAiKey;
-    @Bean
-    public RestTemplate template(){
+
+    @Bean("openAiRestTemplate")
+    public RestTemplate openAiRestTemplate(){
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getInterceptors().add((request, body, execution) -> {
             request.getHeaders().add("Authorization", "Bearer " + openAiKey);

--- a/Backend/src/main/java/com/demo/nimn/config/PaymentConfig.java
+++ b/Backend/src/main/java/com/demo/nimn/config/PaymentConfig.java
@@ -4,10 +4,9 @@ import com.siot.IamportRestClient.IamportClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
 
 @Configuration
-public class AppConfig {
+public class PaymentConfig {
     @Value("${import.apiKey}")
     String apiKey;
 
@@ -17,10 +16,5 @@ public class AppConfig {
     @Bean
     public IamportClient iamportClient() {
         return new IamportClient(apiKey, secretKey);
-    }
-
-    @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
     }
 }

--- a/Backend/src/main/java/com/demo/nimn/config/RestTemplateConfig.java
+++ b/Backend/src/main/java/com/demo/nimn/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.demo.nimn.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean("generalRestTemplate")
+    public RestTemplate generalRestTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/Backend/src/main/java/com/demo/nimn/service/ai/AiService.java
+++ b/Backend/src/main/java/com/demo/nimn/service/ai/AiService.java
@@ -1,0 +1,6 @@
+package com.demo.nimn.service.ai;
+
+public interface AiService {
+    String generateFood(String price);
+    String generateFoodImage(String foodDescription);
+}

--- a/Backend/src/main/java/com/demo/nimn/service/ai/AiServiceImpl.java
+++ b/Backend/src/main/java/com/demo/nimn/service/ai/AiServiceImpl.java
@@ -1,0 +1,97 @@
+package com.demo.nimn.service.ai;
+
+import com.demo.nimn.dto.chatgpt.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class AiServiceImpl implements AiService {
+
+    private final RestTemplate restTemplate;
+    private final Logger logger = LoggerFactory.getLogger(AiServiceImpl.class);
+
+    @Value("${openai.chatModel}")
+    private String chatModel;
+
+    @Value("${openai.api.chatUrl}")
+    private String chatApiURL;
+
+    @Value("${openai.api.imageUrl}")
+    private String imageApiURL;
+
+    @Value("${openai.imageModel}")
+    private String imageModel;
+
+    @Autowired
+    public AiServiceImpl(@Qualifier("openAiRestTemplate") RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public String generateFood(String price) {
+        String prompt = buildMealPlanPrompt(price);
+
+        ChatRequest request = new ChatRequest(chatModel, prompt);
+        ChatResponse chatResponse = restTemplate.postForObject(chatApiURL, request, ChatResponse.class);
+
+        validateChatResponse(chatResponse);
+
+        return chatResponse.getChoices().get(0).getMessage().getContent();
+    }
+
+    @Override
+    public String generateFoodImage(String foodDescription) {
+        String prompt = buildImagePrompt(foodDescription);
+        logger.info("Image generation prompt: {}", prompt);
+
+//        ImageRequest imageRequest = new ImageRequest(imageModel, prompt, "b64_json");
+//        ImageResponse imageResponse = template.postForObject(imageApiURL, imageRequest, ImageResponse.class);
+//        String b64_image = imageResponse.getData().get(0).getB64_json();
+//        byte[] decodedBytes = Base64.getDecoder().decode(b64_image);
+
+        // TODO-jh: 이미지 생성 반환 format b64_json으로 변경해서 저장 필요. open ai에서 생성한 url은 1시간 후 자동 삭제 됨.
+        ImageRequest imageRequest = new ImageRequest(imageModel, prompt, "url");
+        ImageResponse imageResponse = restTemplate.postForObject(imageApiURL, imageRequest, ImageResponse.class);
+
+        validateImageResponse(imageResponse);
+
+        return imageResponse.getData().get(0).getUrl();
+    }
+
+    private String buildMealPlanPrompt(String price) {
+        return "가격: " + price + "원\n이 가격에 맞는 영양 있는 식단을 구성해줘. " +
+                "식단은 MainMenu 2개와 SideMenu 3개로 구성되어야 해. 식단의 이름도 정해줘.";
+    }
+
+    private String buildImagePrompt(String menuDescription) {
+        return menuDescription + "\n다음 식단 메뉴 5가지로만 구성된 이미지를 생성해줘, " +
+                "다른 부가적인 요소들은 빼고 테이블과 메뉴 5가지만 보여줘";
+    }
+
+    private void validateChatResponse(ChatResponse chatResponse) {
+        if (chatResponse == null || chatResponse.getChoices().isEmpty()) {
+            throw new IllegalStateException("ChatGPT API 응답이 유효하지 않습니다.");
+        }
+
+        String content = chatResponse.getChoices().get(0).getMessage().getContent();
+        if (content == null || content.isEmpty()) {
+            throw new IllegalStateException("ChatGPT API 응답 내용이 비어 있습니다.");
+        }
+    }
+
+    private void validateImageResponse(ImageResponse imageResponse) {
+        if (imageResponse == null || imageResponse.getData().isEmpty()) {
+            throw new IllegalStateException("이미지 생성 API 응답이 유효하지 않습니다.");
+        }
+
+        String url = imageResponse.getData().get(0).getUrl();
+        if (url == null || url.isEmpty()) {
+            throw new IllegalStateException("생성된 이미지 URL이 비어 있습니다.");
+        }
+    }
+}

--- a/Backend/src/main/java/com/demo/nimn/service/image/ImageServiceImpl.java
+++ b/Backend/src/main/java/com/demo/nimn/service/image/ImageServiceImpl.java
@@ -6,6 +6,7 @@ import com.demo.nimn.dto.image.ImageDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class ImageServiceImpl implements ImageService{
     private String imageURI = "http://3.37.64.39:8000";
 
     @Autowired
+    @Qualifier("generalRestTemplate")
     private RestTemplate restTemplate;
 
     private final ImageDAO imageDAO;

--- a/Backend/src/main/java/com/demo/nimn/service/meal/MealServiceImpl.java
+++ b/Backend/src/main/java/com/demo/nimn/service/meal/MealServiceImpl.java
@@ -10,6 +10,7 @@ import com.demo.nimn.service.review.ReviewService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -50,7 +51,7 @@ public class MealServiceImpl implements MealService {
     @Autowired
     public MealServiceImpl(MealDAO mealDAO,
                            WeeklyMealPlanDAO weeklyMealPlanDAO,
-                           RestTemplate template,
+                           @Qualifier("openAiRestTemplate") RestTemplate template,
                            CommunicationService communicationService,
                            ReviewService reviewService) {
         this.mealDAO = mealDAO;


### PR DESCRIPTION
<!-- 
PR 제목 작성 가이드:
형식: [타입]: 간단한 설명 (#이슈번호)

타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정  
- docs: 문서 수정
- style: 코드 포맷팅
- refactor: 코드 리팩토링
- test: 테스트 추가/수정
- chore: 빌드, 패키지 등 기타 작업

예시: feat: 사용자 로그인 API 구현 (#123)
-->

## 📝 작업 내용
<!-- 이번 PR에서 구현한 기능이나 수정한 내용을 구체적으로 작성해주세요 -->
- AiService 추가하여 외부 API 로직 이관
- MealService에서 AiService 사용
- RestTemplate는 중복된 로직이 아닌 각각 필요한 로직이라 현행 유지
- AppConfig -> PaymentConfig 파일 이름 명확하게 변경
- RestTemplateConfig 파일 생성 후 generalRestTemplate Bean 생성

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Close #39 
- Close #43 

## 💬 추가 요청사항
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 질문이 있다면 작성해주세요 --> 
- @hdg5639 Food 생성할 때 AiService 사용하시면 됩니다.

## ✅ 체크리스트
### 코드 품질
- [x] 커밋 컨벤션 준수 (feat/fix/docs/refactor 등)
- [x] 불필요한 코드/주석 제거

### 테스트
- [x] 로컬 환경에서 동작 확인 완료
- [x] 기존 기능에 영향 없음 확인

### 리뷰
- [x] 적절한 리뷰어 지정 완료
- [x] 리뷰어 1명 이상 승인

### 배포 준비
- [x] 환경변수 추가/변경사항 문서화
- [x] DB 마이그레이션 필요 여부 확인
- [x] 배포 시 주의사항 없음
