### PR TITLE
design: 대시보드 및 식단 관리 수정, 주문 관리 추가(#5)

### DIFF
--- a/Frontend/src/CSS/Admin.css
+++ b/Frontend/src/CSS/Admin.css
@@ -179,12 +179,8 @@
   transition: all 0.3s ease;
 }
 
-.admin_dashboard_card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
-}
 
-.admin_dashboard_card:nth-child(2) {
+.admin_dashboard_card:nth-child(1) {
   border-left-color: #6b8e5a;
 }
 
@@ -207,7 +203,7 @@
   color: #9d9274;
 }
 
-.admin_dashboard_card:nth-child(2) .admin_card_icon {
+.admin_card_icon.diet_icon {
   color: #6b8e5a;
 }
 
@@ -245,6 +241,9 @@
   margin-bottom: 20px;
   padding-bottom: 10px;
   border-bottom: 2px solid #f8f9fa;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .admin_list_title {
@@ -252,6 +251,20 @@
   font-weight: 600;
   color: #333;
   margin: 0;
+}
+
+.admin_more_btn {
+  background: none;
+  border: none;
+  color: #9d9274;
+  font-size: 14px;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: all 0.3s ease;
+}
+
+.admin_more_btn:hover {
+  color: #8a805f;
 }
 
 .admin_simple_list {
@@ -276,20 +289,99 @@
   border-left-color: #9d9274;
 }
 
-.admin_item_info {
+.admin_simple_item.clickable {
+  cursor: pointer;
+}
+
+.admin_simple_item.no_hover:hover {
+  background: #f8f9fa;
+  border-left-color: transparent;
+}
+
+/* 대시보드 식단 리스트 스타일 */
+.admin_dashboard_diet_list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.admin_dashboard_diet_item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+  border-left: 3px solid transparent;
+  cursor: pointer;
+}
+
+.admin_dashboard_diet_item:hover {
+  background: #f0f2f5;
+  border-left-color: #9d9274;
+}
+
+.admin_dashboard_diet_info {
   flex: 1;
 }
 
-.admin_item_name {
+.admin_dashboard_diet_name {
   font-weight: 600;
   color: #333;
   margin-bottom: 4px;
 }
 
-.admin_item_email,
-.admin_item_detail {
+.admin_dashboard_diet_detail {
   font-size: 14px;
   color: #666;
+}
+
+/* 대시보드 주문 리스트 스타일 */
+.admin_dashboard_order_list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.admin_dashboard_order_item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  border-left: 3px solid transparent;
+}
+
+/* 호버 효과 완전 제거 */
+.admin_dashboard_order_item:hover {
+  background: #f8f9fa;
+  border-left-color: transparent;
+}
+
+.admin_dashboard_order_info {
+  flex: 1;
+}
+
+.admin_dashboard_order_name {
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 4px;
+}
+
+.admin_dashboard_order_detail {
+  font-size: 14px;
+  color: #666;
+}
+
+.admin_dashboard_order_date {
+  font-size: 12px;
+  color: #9d9274;
+  font-weight: 500;
+  padding: 4px 8px;
+  background: rgba(157, 146, 116, 0.1);
+  border-radius: 4px;
 }
 
 .admin_item_date {
@@ -301,8 +393,8 @@
   border-radius: 4px;
 }
 
-/* 사용자 관리 섹션 */
-.admin_users_section {
+/* 주문 관리 섹션 */
+.admin_orders_section {
   background: white;
   border-radius: 12px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
@@ -310,14 +402,15 @@
   padding: 30px;
 }
 
-/* 사용자 테이블 스타일 */
-.admin_users_table {
+/* 주문 테이블 스타일 */
+.admin_orders_table {
   width: 100%;
   background: white;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
   margin-bottom: 20px;
+  border-collapse: collapse;
 }
 
 .admin_table_head {
@@ -346,9 +439,6 @@
   color: #666;
 }
 
-.admin_table_body .admin_table_row:hover {
-  background: #f8f9fa;
-}
 
 .admin_table_body .admin_table_row:nth-child(even) {
   background: #fafbfc;
@@ -584,7 +674,6 @@
   border: 1px solid #e9ecef;
   display: flex;
   flex-direction: column;
- 
 }
 
 /* 첫 번째 섹션 - 이미지와 기본 정보 */
@@ -610,11 +699,6 @@
   border-radius: 16px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
   transition: all 0.3s ease;
-}
-
-.admin_diet_image:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.16);
 }
 
 .admin_diet_info_container {
@@ -647,11 +731,6 @@
   transition: all 0.3s ease;
 }
 
-.admin_diet_info:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-  background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%);
-}
 
 .admin_info_icon {
   font-size: 20px;
@@ -706,11 +785,7 @@
   transition: all 0.3s ease;
 }
 
-.admin_menu_item:hover {
-  transform: translateX(5px);
-  box-shadow: 0 4px 12px rgba(157, 146, 116, 0.15);
-  border-color: #9d9274;
-}
+
 
 .admin_menu_label {
   font-weight: 600;
@@ -757,11 +832,6 @@
   transition: all 0.3s ease;
 }
 
-.admin_nutrition_item:hover {
-  transform: translateX(5px);
-  box-shadow: 0 4px 12px rgba(107, 142, 90, 0.15);
-  border-color: #6b8e5a;
-}
 
 .admin_nutrition_label {
   font-size: 15px;
@@ -827,11 +897,6 @@
   transition: all 0.3s ease;
 }
 
-.admin_summary_item:hover {
-  transform: translateX(5px);
-  box-shadow: 0 4px 12px rgba(212, 197, 160, 0.15);
-  border-color: #d4c5a0;
-}
 
 .admin_summary_label {
   color: #6c757d;
@@ -843,53 +908,7 @@
   font-weight: 700;
 }
 
-/* 액션 버튼 */
-.admin_action_buttons {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 15px;
-  margin-top: auto;
-}
 
-.admin_apply_btn {
-  padding: 18px 24px;
-  background: linear-gradient(135deg, #6b8e5a 0%, #5a7a4a 100%);
-  color: white;
-  border: none;
-  border-radius: 12px;
-  cursor: pointer;
-  font-size: 15px;
-  font-weight: 600;
-  transition: all 0.3s ease;
-  box-shadow: 0 6px 18px rgba(107, 142, 90, 0.3);
-  white-space: nowrap;
-}
-
-.admin_apply_btn:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 24px rgba(107, 142, 90, 0.4);
-  background: linear-gradient(135deg, #5a7a4a 0%, #4a6a3a 100%);
-}
-
-.admin_regenerate_btn {
-  padding: 18px 24px;
-  background: linear-gradient(135deg, #6c757d 0%, #5a6268 100%);
-  color: white;
-  border: none;
-  border-radius: 12px;
-  cursor: pointer;
-  font-size: 15px;
-  font-weight: 600;
-  transition: all 0.3s ease;
-  box-shadow: 0 6px 18px rgba(108, 117, 125, 0.3);
-  white-space: nowrap;
-}
-
-.admin_regenerate_btn:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 24px rgba(108, 117, 125, 0.4);
-  background: linear-gradient(135deg, #5a6268 0%, #495057 100%);
-}
 
 /* 식단 목록 컨테이너 */
 .admin_diet_list_container {
@@ -905,6 +924,50 @@
   margin-bottom: 25px;
   padding-bottom: 15px;
   border-bottom: 2px solid #f8f9fa;
+}
+
+.admin_filter_section {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.admin_price_filter {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  background: white;
+  transition: all 0.3s ease;
+  min-width: 120px;
+}
+
+.admin_price_filter:focus {
+  border-color: #9d9274;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(157, 146, 116, 0.1);
+}
+
+.admin_filter_section {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+.admin_price_filter {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  background: white;
+  transition: all 0.3s ease;
+  min-width: 120px;
+}
+
+.admin_price_filter:focus {
+  border-color: #9d9274;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(157, 146, 116, 0.1);
 }
 
 .admin_list_count {
@@ -940,6 +1003,7 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   border: 1px solid #f0f0f0;
   transition: all 0.3s ease;
+  cursor: pointer;
 }
 
 .admin_diet_list_item:hover {
@@ -1039,6 +1103,47 @@
   background: #c82333;
 }
 
+/* 식단 상세 컨테이너 */
+.admin_diet_detail_container {
+  padding: 30px;
+  max-height: calc(100vh - 300px);
+  overflow-y: auto;
+}
+
+.admin_diet_detail_header {
+  margin-bottom: 25px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.admin_back_btn {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  color: #6c757d;
+  padding: 10px 15px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  align-self: flex-start;
+}
+
+.admin_back_btn:hover {
+  background: #e9ecef;
+  border-color: #9d9274;
+  color: #9d9274;
+}
+
+.admin_detail_main_title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #2c3e50;
+  margin: 0;
+  text-align: center;
+}
+
 /* 빈 상태 스타일 */
 .admin_empty_state {
   text-align: center;
@@ -1079,26 +1184,30 @@
 /* 스크롤바 스타일 */
 .admin_diet_create_container::-webkit-scrollbar,
 .admin_diet_list_container::-webkit-scrollbar,
-.admin_diet_list_content::-webkit-scrollbar {
+.admin_diet_list_content::-webkit-scrollbar,
+.admin_diet_detail_container::-webkit-scrollbar {
   width: 6px;
 }
 
 .admin_diet_create_container::-webkit-scrollbar-track,
 .admin_diet_list_container::-webkit-scrollbar-track,
-.admin_diet_list_content::-webkit-scrollbar-track {
+.admin_diet_list_content::-webkit-scrollbar-track,
+.admin_diet_detail_container::-webkit-scrollbar-track {
   background: #f1f1f1;
   border-radius: 3px;
 }
 
 .admin_diet_create_container::-webkit-scrollbar-thumb,
 .admin_diet_list_container::-webkit-scrollbar-thumb,
-.admin_diet_list_content::-webkit-scrollbar-thumb {
+.admin_diet_list_content::-webkit-scrollbar-thumb,
+.admin_diet_detail_container::-webkit-scrollbar-thumb {
   background: #9d9274;
   border-radius: 3px;
 }
 
 .admin_diet_create_container::-webkit-scrollbar-thumb:hover,
 .admin_diet_list_container::-webkit-scrollbar-thumb:hover,
-.admin_diet_list_content::-webkit-scrollbar-thumb:hover {
+.admin_diet_list_content::-webkit-scrollbar-thumb:hover,
+.admin_diet_detail_container::-webkit-scrollbar-thumb:hover {
   background: #8a805f;
 }

--- a/Frontend/src/pages/Admin.jsx
+++ b/Frontend/src/pages/Admin.jsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect } from "react";
 import '../CSS/Admin.css';
 import { useNavigate } from 'react-router-dom';
-import foodimage from'../images/mainCardImg1.jpeg';
 
 function Admin() {
   const [activeTab, setActiveTab] = useState('dashboard');
-  const [dietSubTab, setDietSubTab] = useState('create'); // 식단 관리 내 서브탭
-  const [users, setUsers] = useState([]);
+  const [dietSubTab, setDietSubTab] = useState('create');
+  const [dietDetailSubTab, setDietDetailSubTab] = useState('list');
+  const [selectedDiet, setSelectedDiet] = useState(null);
+  const [orderSubTab, setOrderSubTab] = useState('list');
+  const [orders, setOrders] = useState([]);
   const [dietList, setDietList] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
+  const [priceFilter, setPriceFilter] = useState('all');
   const [price, setPrice] = useState('');
   const [loading, setLoading] = useState(false);
   const [item, setItem] = useState({
@@ -30,6 +33,8 @@ function Admin() {
   const [itemVisible, setItemVisible] = useState(false);
   const navigate = useNavigate();
 
+  const foodimage = 'https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=400&h=300&fit=crop';
+
   const handleLogout = () => {
     localStorage.removeItem("token");
     localStorage.removeItem("email");
@@ -41,19 +46,15 @@ function Admin() {
     setPrice(selectedPrice);
   };
 
-  // 식단 생성 fetch
   const handleButtonClick = async () => {
     if (!price) {
       alert('가격을 선택해주세요.');
       return;
     }
 
-    const token = localStorage.getItem("token");
     setLoading(true);
     
-    // 예시 데이터를 사용한 시뮬레이션
     try {
-      // 실제 API 호출 대신 예시 데이터 사용
       setTimeout(() => {
         const exampleMenus = {
           "4000": {
@@ -84,7 +85,8 @@ function Admin() {
             fat: "12g",
             sugar: "6g",
             sodium: "750mg",
-            image: foodimage          },
+            image: foodimage
+          },
           "7000": {
             name: "프리미엄 한식 세트",
             main1: "갈비찜",
@@ -98,7 +100,8 @@ function Admin() {
             fat: "22g",
             sugar: "12g",
             sodium: "1200mg",
-            image: foodimage          }
+            image: foodimage
+          }
         };
 
         const selectedMenu = exampleMenus[price];
@@ -108,40 +111,7 @@ function Admin() {
         });
         setItemVisible(true);
         setLoading(false);
-      }, 2000); // 2초 로딩 시뮬레이션
-
-      // 실제 API 호출 코드 (주석 처리)
-      /*
-      const response = await fetch(`http://3.37.64.39:8000/api/meal/food-menu?price=${price}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": token,
-        },
-      });
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
-      }
-      const data = await response.json();
-      setItem({
-        name: data.name,
-        main1: data.main1,
-        main2: data.main2,
-        price: `${price}원`,
-        side1: data.side1,
-        side2: data.side2,
-        side3: data.side3,
-        calories: data.calories,
-        carbohydrate: data.carbohydrate,
-        protein: data.protein,
-        fat: data.fat,
-        sugar: data.sugar,
-        sodium: data.sodium,
-        image: data.image
-      });
-      setItemVisible(true);
-      setLoading(false);
-      */
+      }, 2000);
     } catch (error) {
       console.error('Fetch error:', error);
       setLoading(false);
@@ -149,7 +119,6 @@ function Admin() {
     }
   };
 
-  // 식단 적용 버튼
   const handleApplyDiet = () => {
     const newDiet = {
       id: dietList.length + 1,
@@ -162,40 +131,85 @@ function Admin() {
     alert('식단이 적용되었습니다!');
   };
 
-  // 사용자 정보 가져오기 (예시 데이터)
+  const handleDietClick = (diet) => {
+    setSelectedDiet(diet);
+    if (activeTab === 'dashboard') {
+      setActiveTab('diet');
+      setDietSubTab('list');
+      setDietDetailSubTab('detail');
+    } else {
+      setDietDetailSubTab('detail');
+    }
+  };
+
+  const handleViewMoreDiets = () => {
+    setActiveTab('diet');
+    setDietSubTab('list');
+    setDietDetailSubTab('list');
+  };
+
+  const handleViewMoreOrders = () => {
+    setActiveTab('orders');
+    setOrderSubTab('list');
+  };
+
+  // 가격 필터링 함수
+  const getFilteredDietList = () => {
+    if (priceFilter === 'all') {
+      return dietList;
+    }
+    return dietList.filter(diet => diet.price === `${priceFilter}원`);
+  };
+
+  const filteredDietList = getFilteredDietList();
+
   useEffect(() => {
-    const mockUsers = [
+    const mockOrders = [
       {
         id: 1,
-        name: "테스트1",
-        email: "test1@naver.com",
-        phone: "01012345678",
-        postcode: "12345",
-        address: "도봉구 주소",
-        detail: "상세 주소"
+        paymentDate: "2025-06-26",
+        userName: "김영희",
+        amount: "7000원"
       },
       {
         id: 2,
-        name: "테스트",
-        email: "test14@naver.com",
-        phone: "010-2222-3333",
-        postcode: "13480",
-        address: "경기 성남시 분당구 대왕판교로 477",
-        detail: "111"
+        paymentDate: "2025-06-25",
+        userName: "이철수",
+        amount: "5500원"
       },
       {
         id: 3,
-        name: "테스트2",
-        email: "test3@naver.com",
-        phone: "01012345678",
-        postcode: "12345",
-        address: "도봉구 주소",
-        detail: "상세 주소"
+        paymentDate: "2025-06-25",
+        userName: "박민수",
+        amount: "4000원"
+      },
+      {
+        id: 4,
+        paymentDate: "2025-06-24",
+        userName: "정수연",
+        amount: "7000원"
+      },
+      {
+        id: 5,
+        paymentDate: "2025-06-24",
+        userName: "최지영",
+        amount: "5500원"
+      },
+      {
+        id: 6,
+        paymentDate: "2025-06-23",
+        userName: "김태호",
+        amount: "7000원"
+      },
+      {
+        id: 7,
+        paymentDate: "2025-06-23",
+        userName: "이미영",
+        amount: "4000원"
       }
     ];
-    setUsers(mockUsers);
+    setOrders(mockOrders);
 
-    // 예시 식단 데이터
     const mockDietList = [
       {
         id: 1,
@@ -309,10 +323,10 @@ function Admin() {
     setDietList(mockDietList);
   }, []);
 
-  const usersPerPage = 5;
-  const totalPages = Math.ceil(users.length / usersPerPage);
-  const startIndex = (currentPage - 1) * usersPerPage;
-  const currentUsers = users.slice(startIndex, startIndex + usersPerPage);
+  const ordersPerPage = 10;
+  const totalOrderPages = Math.ceil(orders.length / ordersPerPage);
+  const startOrderIndex = (currentPage - 1) * ordersPerPage;
+  const currentOrders = orders.slice(startOrderIndex, startOrderIndex + ordersPerPage);
 
   return (
     <div className="admin_layout">
@@ -335,18 +349,18 @@ function Admin() {
             <span className="admin_nav_text">대시보드</span>
           </button>
           <button 
-            className={`admin_nav_button ${activeTab === 'users' ? 'admin_nav_active' : ''}`}
-            onClick={() => setActiveTab('users')}
-          >
-            <span className="admin_nav_icon">👥</span>
-            <span className="admin_nav_text">유저 관리</span>
-          </button>
-          <button 
             className={`admin_nav_button ${activeTab === 'diet' ? 'admin_nav_active' : ''}`}
             onClick={() => setActiveTab('diet')}
           >
             <span className="admin_nav_icon">🍽️</span>
             <span className="admin_nav_text">식단 관리</span>
+          </button>
+          <button 
+            className={`admin_nav_button ${activeTab === 'orders' ? 'admin_nav_active' : ''}`}
+            onClick={() => setActiveTab('orders')}
+          >
+            <span className="admin_nav_icon">📦</span>
+            <span className="admin_nav_text">주문 관리</span>
           </button>
         </nav>
       </div>
@@ -358,8 +372,8 @@ function Admin() {
             <h1 className="admin_title">우리동네영양사</h1>
             <div className="admin_breadcrumb">
               {activeTab === 'dashboard' && '대시보드'}
-              {activeTab === 'users' && '유저 정보'}
               {activeTab === 'diet' && '식단 관리'}
+              {activeTab === 'orders' && '주문 관리'}
             </div>
           </div>
           <div className="admin_header_right">
@@ -378,23 +392,23 @@ function Admin() {
               <div className="admin_dashboard_grid">
                 <div className="admin_dashboard_card">
                   <div className="admin_card_header">
-                    <h3 className="admin_card_title">전체 유저</h3>
-                    <span className="admin_card_icon">👥</span>
+                    <h3 className="admin_card_title">생성된 식단</h3>
+                    <span className="admin_card_icon diet_icon">🍽️</span>
                   </div>
                   <div className="admin_card_content">
-                    <div className="admin_card_number">{users.length}</div>
-                    <div className="admin_card_label">명</div>
+                    <div className="admin_card_number">{dietList.length}</div>
+                    <div className="admin_card_label">개</div>
                   </div>
                 </div>
 
                 <div className="admin_dashboard_card">
                   <div className="admin_card_header">
-                    <h3 className="admin_card_title">생성된 식단</h3>
-                    <span className="admin_card_icon">🍽️</span>
+                    <h3 className="admin_card_title">총 주문</h3>
+                    <span className="admin_card_icon">📦</span>
                   </div>
                   <div className="admin_card_content">
-                    <div className="admin_card_number">{dietList.length}</div>
-                    <div className="admin_card_label">개</div>
+                    <div className="admin_card_number">{orders.length}</div>
+                    <div className="admin_card_label">건</div>
                   </div>
                 </div>
               </div>
@@ -402,14 +416,21 @@ function Admin() {
               <div className="admin_dashboard_lists">
                 <div className="admin_list_container">
                   <div className="admin_list_header">
-                    <h3 className="admin_list_title">최근 유저</h3>
+                    <h3 className="admin_list_title">전체 식단</h3>
+                    <button className="admin_more_btn" onClick={handleViewMoreDiets}>
+                      목록보기
+                    </button>
                   </div>
-                  <div className="admin_simple_list">
-                    {users.slice(0, 5).map((user) => (
-                      <div key={user.id} className="admin_simple_item">
-                        <div className="admin_item_info">
-                          <div className="admin_item_name">{user.name}</div>
-                          <div className="admin_item_email">{user.email}</div>
+                  <div className="admin_dashboard_diet_list">
+                    {dietList.slice(0, 5).map((diet) => (
+                      <div 
+                        key={diet.id} 
+                        className="admin_dashboard_diet_item"
+                        onClick={() => handleDietClick(diet)}
+                      >
+                        <div className="admin_dashboard_diet_info">
+                          <div className="admin_dashboard_diet_name">{diet.name}</div>
+                          <div className="admin_dashboard_diet_detail">{diet.price} • {diet.calories}</div>
                         </div>
                       </div>
                     ))}
@@ -418,16 +439,19 @@ function Admin() {
 
                 <div className="admin_list_container">
                   <div className="admin_list_header">
-                    <h3 className="admin_list_title">최근 생성 식단</h3>
+                    <h3 className="admin_list_title">최근 주문 내역</h3>
+                    <button className="admin_more_btn" onClick={handleViewMoreOrders}>
+                      목록보기
+                    </button>
                   </div>
-                  <div className="admin_simple_list">
-                    {dietList.slice(0, 5).map((diet) => (
-                      <div key={diet.id} className="admin_simple_item">
-                        <div className="admin_item_info">
-                          <div className="admin_item_name">{diet.name}</div>
-                          <div className="admin_item_detail">{diet.price} • {diet.calories}</div>
+                  <div className="admin_dashboard_order_list">
+                    {orders.slice(0, 5).map((order) => (
+                      <div key={order.id} className="admin_dashboard_order_item">
+                        <div className="admin_dashboard_order_info">
+                          <div className="admin_dashboard_order_name">{order.userName}</div>
+                          <div className="admin_dashboard_order_detail">{order.amount}</div>
                         </div>
-                        <div className="admin_item_date">{diet.createdAt}</div>
+                        <div className="admin_dashboard_order_date">{order.paymentDate}</div>
                       </div>
                     ))}
                   </div>
@@ -436,33 +460,27 @@ function Admin() {
             </div>
           )}
 
-          {/* 유저 관리 */}
-          {activeTab === 'users' && (
-            <div className="admin_users_section">
+          {/* 주문 관리 */}
+          {activeTab === 'orders' && (
+            <div className="admin_orders_section">
               <div className="admin_section_header">
-                <h2 className="admin_section_title">전체 유저 정보</h2>
+                <h2 className="admin_section_title">주문 관리</h2>
               </div>
               
-              <table className="admin_users_table">
+              <table className="admin_orders_table">
                 <thead className="admin_table_head">
                   <tr className="admin_table_row">
-                    <th className="admin_table_header">이름</th>
-                    <th className="admin_table_header">이메일</th>
-                    <th className="admin_table_header">전화번호</th>
-                    <th className="admin_table_header">우편번호</th>
-                    <th className="admin_table_header">도로명 주소</th>
-                    <th className="admin_table_header">상세 주소</th>
+                    <th className="admin_table_header">결제 날짜</th>
+                    <th className="admin_table_header">유저 이름</th>
+                    <th className="admin_table_header">결제 금액</th>
                   </tr>
                 </thead>
                 <tbody className="admin_table_body">
-                  {currentUsers.map((user) => (
-                    <tr key={user.id} className="admin_table_row">
-                      <td className="admin_table_cell">{user.name}</td>
-                      <td className="admin_table_cell">{user.email}</td>
-                      <td className="admin_table_cell">{user.phone}</td>
-                      <td className="admin_table_cell">{user.postcode}</td>
-                      <td className="admin_table_cell">{user.address}</td>
-                      <td className="admin_table_cell">{user.detail}</td>
+                  {currentOrders.map((order) => (
+                    <tr key={order.id} className="admin_table_row">
+                      <td className="admin_table_cell">{order.paymentDate}</td>
+                      <td className="admin_table_cell">{order.userName}</td>
+                      <td className="admin_table_cell">{order.amount}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -479,8 +497,8 @@ function Admin() {
                 <span className="admin_page_number">{currentPage}</span>
                 <button 
                   className="admin_pagination_btn"
-                  onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
-                  disabled={currentPage === totalPages}
+                  onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalOrderPages))}
+                  disabled={currentPage === totalOrderPages}
                 >
                   다음
                 </button>
@@ -491,18 +509,23 @@ function Admin() {
           {/* 식단 관리 */}
           {activeTab === 'diet' && (
             <div className="admin_diet_section">
-          
               {/* 식단 관리 서브탭 */}
               <div className="admin_diet_subtabs">
                 <button 
                   className={`admin_subtab_btn ${dietSubTab === 'create' ? 'admin_subtab_active' : ''}`}
-                  onClick={() => setDietSubTab('create')}
+                  onClick={() => {
+                    setDietSubTab('create');
+                    setDietDetailSubTab('list');
+                  }}
                 >
                   🍽️ 식단 생성하기
                 </button>
                 <button 
                   className={`admin_subtab_btn ${dietSubTab === 'list' ? 'admin_subtab_active' : ''}`}
-                  onClick={() => setDietSubTab('list')}
+                  onClick={() => {
+                    setDietSubTab('list');
+                    setDietDetailSubTab('list');
+                  }}
                 >
                   📋 생성된 식단 ({dietList.length})
                 </button>
@@ -539,7 +562,7 @@ function Admin() {
                     {itemVisible && !loading && (
                       <div className="admin_diet_result">
                         <div className="admin_result_header">
-                          <h4 className="admin_result_title">✨ 생성된 식단</h4>
+                          <h4 className="admin_result_title"> 생성된 식단</h4>
                           <span className="admin_new_badge">NEW</span>
                         </div>
                         <div className="admin_diet_card">
@@ -553,11 +576,9 @@ function Admin() {
                                 <h3 className="admin_diet_name">{item.name}</h3>
                                 <div className="admin_diet_info_summary">
                                   <div className="admin_diet_info">
-                                    <span className="admin_info_icon">🔥</span>
                                     <span className="admin_info_text">{item.calories}</span>
                                   </div>
                                   <div className="admin_diet_info">
-                                    <span className="admin_info_icon">💰</span>
                                     <span className="admin_info_text">{item.price}</span>
                                   </div>
                                 </div>
@@ -641,15 +662,6 @@ function Admin() {
                                   </div>
                                 </div>
                               </div>
-
-                              <div className="admin_action_buttons">
-                                <button className="admin_apply_btn" onClick={handleApplyDiet}>
-                                  ✅ 식단 적용하기
-                                </button>
-                                <button className="admin_regenerate_btn" onClick={handleButtonClick}>
-                                  🔄 다시 생성하기
-                                </button>
-                              </div>
                             </div>
                           </div>
                         </div>
@@ -661,57 +673,188 @@ function Admin() {
 
               {/* 생성된 식단 목록 탭 */}
               {dietSubTab === 'list' && (
-                <div className="admin_diet_list_container">
-                  <div className="admin_diet_list_header">
-                    <h3 className="admin_list_title">생성된 식단 목록</h3>
-                    <span className="admin_list_count">총 {dietList.length}개</span>
-                  </div>
-                  <div className="admin_diet_list_content">
-                    {dietList.length > 0 ? (
-                      <div className="admin_diet_list">
-                        {dietList.map((diet) => (
-                          <div key={diet.id} className="admin_diet_list_item">
-                            <div className="admin_diet_list_image">
-                              <img src={diet.image} alt={diet.name} />
-                            </div>
-                            <div className="admin_diet_list_info">
-                              <div className="admin_diet_list_name">{diet.name}</div>
-                              <div className="admin_diet_list_details">
-                                <span>{diet.price}</span>
-                                <span>•</span>
-                                <span>{diet.calories}</span>
-                                <span>•</span>
-                                <span>메인: {diet.main1}, {diet.main2}</span>
+                <>
+                  {dietDetailSubTab === 'list' && (
+                    <div className="admin_diet_list_container">
+                      <div className="admin_diet_list_header">
+                        <h3 className="admin_list_title">생성된 식단 목록</h3>
+                        <div className="admin_filter_section">
+                          <select 
+                            value={priceFilter} 
+                            onChange={(e) => setPriceFilter(e.target.value)}
+                            className="admin_price_filter"
+                          >
+                            <option value="all">전체 가격</option>
+                            <option value="4000">4000원</option>
+                            <option value="5500">5500원</option>
+                            <option value="7000">7000원</option>
+                          </select>
+                          <span className="admin_list_count">총 {filteredDietList.length}개</span>
+                        </div>
+                      </div>
+                      <div className="admin_diet_list_content">
+                        {filteredDietList.length > 0 ? (
+                          <div className="admin_diet_list">
+                            {filteredDietList.map((diet) => (
+                              <div 
+                                key={diet.id} 
+                                className="admin_diet_list_item"
+                                onClick={() => handleDietClick(diet)}
+                              >
+                                <div className="admin_diet_list_image">
+                                  <img src={diet.image} alt={diet.name} />
+                                </div>
+                                <div className="admin_diet_list_info">
+                                  <div className="admin_diet_list_name">{diet.name}</div>
+                                  <div className="admin_diet_list_details">
+                                    <span>{diet.price}</span>
+                                    <span>•</span>
+                                    <span>{diet.calories}</span>
+                                    <span>•</span>
+                                    <span>메인: {diet.main1}, {diet.main2}</span>
+                                  </div>
+                                  <div className="admin_diet_list_nutrients">
+                                    단백질: {diet.protein} | 탄수화물: {diet.carbohydrate} | 지방: {diet.fat}
+                                  </div>
+                                </div>
+                                <div className="admin_diet_list_meta">
+                                  <div className="admin_diet_list_actions">
+                                    <button className="admin_diet_action_btn admin_delete_btn">삭제</button>
+                                  </div>
+                                </div>
                               </div>
-                              <div className="admin_diet_list_nutrients">
-                                단백질: {diet.protein} | 탄수화물: {diet.carbohydrate} | 지방: {diet.fat}
-                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="admin_empty_state">
+                            <div className="admin_empty_icon">🍽️</div>
+                            <div className="admin_empty_text">해당 가격대의 식단이 없습니다.</div>
+                            <div className="admin_empty_subtext">
+                              <button 
+                                className="admin_empty_link"
+                                onClick={() => setDietSubTab('create')}
+                              >
+                                새로운 식단 생성하기
+                              </button>
                             </div>
-                            <div className="admin_diet_list_meta">
-                              <div className="admin_diet_list_date">{diet.createdAt}</div>
-                              <div className="admin_diet_list_actions">
-                                <button className="admin_diet_action_btn admin_delete_btn">삭제</button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* 식단 상세 보기 */}
+                  {dietDetailSubTab === 'detail' && selectedDiet && (
+                    <div className="admin_diet_detail_container">
+                      <div className="admin_diet_detail_header">
+                        <button 
+                          className="admin_back_btn"
+                          onClick={() => setDietDetailSubTab('list')}
+                        >
+                          ← 목록으로 돌아가기
+                        </button>
+                        <h3 className="admin_detail_main_title">{selectedDiet.name}</h3>
+                      </div>
+                      
+                      <div className="admin_diet_card">
+                        <div className="admin_diet_content">
+                          {/* 첫 번째 섹션 - 이미지와 기본 정보 */}
+                          <div className="admin_diet_left">
+                            <div className="admin_diet_image_container">
+                              <img src={selectedDiet.image} alt="food" className="admin_diet_image" />
+                            </div>
+                            <div className="admin_diet_info_container">
+                              <h3 className="admin_diet_name">{selectedDiet.name}</h3>
+                              <div className="admin_diet_info_summary">
+                                <div className="admin_diet_info">
+                                  <span className="admin_info_text">{selectedDiet.calories}</span>
+                                </div>
+                                <div className="admin_diet_info">
+                                  <span className="admin_info_text">{selectedDiet.price}</span>
+                                </div>
                               </div>
                             </div>
                           </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="admin_empty_state">
-                        <div className="admin_empty_icon">🍽️</div>
-                        <div className="admin_empty_text">아직 생성된 식단이 없습니다.</div>
-                        <div className="admin_empty_subtext">
-                          <button 
-                            className="admin_empty_link"
-                            onClick={() => setDietSubTab('create')}
-                          >
-                            새로운 식단 생성하기
-                          </button>
+                          
+                          {/* 두 번째 섹션 - 메뉴 구성 */}
+                          <div className="admin_menu_section">
+                            <h4 className="admin_detail_title">메뉴 구성</h4>
+                            <div className="admin_menu_grid">
+                              <div className="admin_menu_item">
+                                <span className="admin_menu_label">메인1:</span>
+                                <span className="admin_menu_value">{selectedDiet.main1}</span>
+                              </div>
+                              <div className="admin_menu_item">
+                                <span className="admin_menu_label">메인2:</span>
+                                <span className="admin_menu_value">{selectedDiet.main2}</span>
+                              </div>
+                              <div className="admin_menu_item">
+                                <span className="admin_menu_label">사이드1:</span>
+                                <span className="admin_menu_value">{selectedDiet.side1}</span>
+                              </div>
+                              <div className="admin_menu_item">
+                                <span className="admin_menu_label">사이드2:</span>
+                                <span className="admin_menu_value">{selectedDiet.side2}</span>
+                              </div>
+                              <div className="admin_menu_item">
+                                <span className="admin_menu_label">사이드3:</span>
+                                <span className="admin_menu_value">{selectedDiet.side3}</span>
+                              </div>
+                            </div>
+                          </div>
+                          
+                          {/* 세 번째 섹션 - 영양성분 */}
+                          <div className="admin_nutrition_section">
+                            <h4 className="admin_detail_title">영양성분</h4>
+                            <div className="admin_nutrition_grid">
+                              <div className="admin_nutrition_item">
+                                <span className="admin_nutrition_label">탄수화물</span>
+                                <span className="admin_nutrition_value">{selectedDiet.carbohydrate}</span>
+                              </div>
+                              <div className="admin_nutrition_item">
+                                <span className="admin_nutrition_label">단백질</span>
+                                <span className="admin_nutrition_value">{selectedDiet.protein}</span>
+                              </div>
+                              <div className="admin_nutrition_item">
+                                <span className="admin_nutrition_label">지방</span>
+                                <span className="admin_nutrition_value">{selectedDiet.fat}</span>
+                              </div>
+                              <div className="admin_nutrition_item">
+                                <span className="admin_nutrition_label">당류</span>
+                                <span className="admin_nutrition_value">{selectedDiet.sugar}</span>
+                              </div>
+                              <div className="admin_nutrition_item">
+                                <span className="admin_nutrition_label">나트륨</span>
+                                <span className="admin_nutrition_value">{selectedDiet.sodium}</span>
+                              </div>
+                            </div>
+                          </div>
+
+                          {/* 네 번째 섹션 - 요약 정보 */}
+                          <div className="admin_diet_extra">
+                            <div className="admin_diet_summary">
+                              <h4 className="admin_summary_title">식단 요약</h4>
+                              <div className="admin_summary_stats">
+                                <div className="admin_summary_item">
+                                  <span className="admin_summary_label">가격대</span>
+                                  <span className="admin_summary_value">{selectedDiet.price}</span>
+                                </div>
+                                <div className="admin_summary_item">
+                                  <span className="admin_summary_label">칼로리</span>
+                                  <span className="admin_summary_value">{selectedDiet.calories}</span>
+                                </div>
+                                <div className="admin_summary_item">
+                                  <span className="admin_summary_label">메뉴 구성</span>
+                                  <span className="admin_summary_value">5개</span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                    )}
-                  </div>
-                </div>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}


### PR DESCRIPTION
## 📝 작업 내용
- 불필요한 호버 삭제
- 대시보드 좌: 식단 개수, 전체식단, 우: 주문 개수, 최근 주문 내역
- 대시보드 -> 전체 식단에서 각 아이템 클릭시 식단 상세 정보 페이지 이동
- 유저 관리 삭제
- 주문 관리 추가  
- 식단 생성하기 불필요한 이모지 제거
- 식단 생성하기 (식단 적용, 재생성 버튼 삭제)
- 생성된 식단에 가격별 필터 적용    

## 🔗 관련 이슈
- Related to #5 

## 💬 추가 요청사항
- 없습니다.

## ✅ 체크리스트
### 코드 품질
- [x] 커밋 컨벤션 준수 (feat/fix/docs/refactor 등)
- [x] 불필요한 코드/주석 제거

### 테스트
- [x] 로컬 환경에서 동작 확인 완료
- [x] 기존 기능에 영향 없음 확인

### 리뷰
- [x] 적절한 리뷰어 지정 완료
- [x] 리뷰어 1명 이상 승인

## 작업물
#### 대시보드
<img width="1454" alt="스크린샷 2025-06-26 오후 8 22 20" src="https://github.com/user-attachments/assets/f872cde4-66c7-4932-b3aa-639e9b35ec1d" />

#### 식단 상세 페이지
<img width="1447" alt="스크린샷 2025-06-26 오후 8 22 45" src="https://github.com/user-attachments/assets/50ed2e3e-ced5-4a42-ad6c-1dc4252c6065" />

#### 주문 관리 탭
<img width="1460" alt="스크린샷 2025-06-26 오후 8 22 52" src="https://github.com/user-attachments/assets/0f5da5f6-35aa-46ec-8139-add41913df99" />

#### 생성된 식단 가격별 필터
<img width="1438" alt="스크린샷 2025-06-26 오후 8 22 38" src="https://github.com/user-attachments/assets/e732e727-c1b2-4464-8417-acfc1d06b82a" />